### PR TITLE
fix: 修复扫描时的显存泄漏问题

### DIFF
--- a/process_assets.py
+++ b/process_assets.py
@@ -28,10 +28,13 @@ def get_image_feature(images):
         return None
     features = None
     try:
-        inputs = processor(images=images, return_tensors="pt")["pixel_values"].to(DEVICE)
-        features = model.get_image_features(inputs)
-        normalized_features = features / torch.norm(features, dim=1, keepdim=True)  # 归一化，方便后续计算余弦相似度
-        features = normalized_features.detach().cpu().numpy()
+        with torch.no_grad():
+            inputs = processor(images=images, return_tensors="pt")["pixel_values"].to(DEVICE)
+            features = model.get_image_features(inputs)
+            normalized_features = features / torch.norm(features, dim=1, keepdim=True)  # 归一化，方便后续计算余弦相似度
+            features = normalized_features.detach().cpu().numpy()
+            del inputs, normalized_features
+            torch.cuda.empty_cache()
     except Exception as e:
         logger.exception("处理图片报错：type=%s error=%s" % (type(images), repr(e)))
         traceback.print_stack()


### PR DESCRIPTION
修复了在进行文件扫描时，由于张量对象未被及时释放而导致的显存持续增长，且在扫描结束后也无法完全释放的问题。
原问题：开启项目前vram占用 2.3G，开启项目后，vram占用3.4G，搜索图片时为3.5G，但扫描图片后，始终在4.5G左右，不会降低，经排查是张量对象未被及时释放而导致，提交pr
目前测试：扫描图片时也仅为3.5G，不会增长。